### PR TITLE
Use pr branch instead of head sha

### DIFF
--- a/src/scripts/prerequisites.sh
+++ b/src/scripts/prerequisites.sh
@@ -59,7 +59,7 @@ else
 	merge_instance_branch_head_sha=$(git rev-parse "origin/${merge_instance_branch}")
 fi
 
-pr_branch_head_sha=$(git rev-parse HEAD)
+pr_branch_head_sha=$(git rev-parse "${pr_branch}")
 
 # When testing, we use the merge-base rather than the HEAD of the target branch
 echo "Checking merge-base of HEAD ($(git rev-parse HEAD || true)) and merge branch (${merge_instance_branch_head_sha})"


### PR DESCRIPTION
Fix to match https://github.com/trunk-io/merge-action/blob/main/src/scripts/prerequisites.sh#L54, which is more correct and fixes some upload cases.