### PR TITLE
Fix the distinction between testing HEAD and PR branch

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -114,7 +114,7 @@ runs:
       env:
         MERGE_INSTANCE_BRANCH_HEAD_SHA:
           ${{ steps.prerequisites.outputs.merge_instance_branch_head_sha }}
-        PR_BRANCH_HEAD_SHA: ${{ steps.prerequisites.outputs.pr_branch_head_sha }}
+        PR_BRANCH_HEAD_SHA: ${{ steps.prerequisites.outputs.pr_branch_upload_head_sha }}
         VERBOSE: ${{ inputs.verbose }}
         WORKSPACE_PATH: ${{ steps.prerequisites.outputs.workspace_path }}
         BAZEL_PATH: ${{ inputs.bazel-path }}
@@ -132,7 +132,7 @@ runs:
         REPOSITORY: ${{ github.repository }}
         TARGET_BRANCH: ${{ steps.prerequisites.outputs.merge_instance_branch }}
         PR_NUMBER: ${{ github.event.pull_request.number }}
-        PR_SHA: ${{ steps.prerequisites.outputs.pr_branch_head_sha }}
+        PR_SHA: ${{ steps.prerequisites.outputs.pr_branch_upload_head_sha }}
         IMPACTED_TARGETS_FILE:
           ${{ steps.compute-impacted-targets-upload.outputs.impacted_targets_out }}
         IMPACTS_ALL_DETECTED: ${{ steps.prerequisites.outputs.impacts_all_detected }}
@@ -148,7 +148,7 @@ runs:
       env:
         # Use base sha instead of merge instance branch head sha for testing
         MERGE_INSTANCE_BRANCH_HEAD_SHA: ${{ steps.prerequisites.outputs.merge_base_sha }}
-        PR_BRANCH_HEAD_SHA: ${{ steps.prerequisites.outputs.pr_branch_head_sha }}
+        PR_BRANCH_HEAD_SHA: ${{ steps.prerequisites.outputs.pr_branch_testing_head_sha }}
         VERBOSE: ${{ inputs.verbose }}
         WORKSPACE_PATH: ${{ steps.prerequisites.outputs.workspace_path }}
         BAZEL_PATH: ${{ inputs.bazel-path }}

--- a/src/scripts/prerequisites.sh
+++ b/src/scripts/prerequisites.sh
@@ -89,11 +89,11 @@ fi
 # Outputs
 if [[ -v GITHUB_OUTPUT && -f ${GITHUB_OUTPUT} ]]; then
 	# trunk-ignore-begin(shellcheck/SC2129)
-	echo "merge_instance_branch=${merge_instance_branch}" >>"${GITHUB_OUTPUT}" # NOTE(TYLER): USED BY UPLOAD
-	echo "merge_instance_branch_head_sha=${merge_instance_branch_head_sha}" >>"${GITHUB_OUTPUT}" # NOTE(TYLER): USED BY BOTH COMPUTE
-	echo "merge_base_sha=${merge_base_sha}" >>"${GITHUB_OUTPUT}" # NOTE(TYLER): USED BY TESTING COMPUTE
-	echo "pr_branch_upload_head_sha=${pr_branch_upload_head_sha}" >>"${GITHUB_OUTPUT}" # NOTE(TYLER): USED BY BOTH COMPUTE AND UPLOAD -> upload and upload compute
-	echo "pr_branch_testing_head_sha=${pr_branch_testing_head_sha}" >>"${GITHUB_OUTPUT}" # NOTE(TYLER): USED BY TESTING COMPUTE
+	echo "merge_instance_branch=${merge_instance_branch}" >>"${GITHUB_OUTPUT}"
+	echo "merge_instance_branch_head_sha=${merge_instance_branch_head_sha}" >>"${GITHUB_OUTPUT}"
+	echo "merge_base_sha=${merge_base_sha}" >>"${GITHUB_OUTPUT}"
+	echo "pr_branch_upload_head_sha=${pr_branch_upload_head_sha}" >>"${GITHUB_OUTPUT}"
+	echo "pr_branch_testing_head_sha=${pr_branch_testing_head_sha}" >>"${GITHUB_OUTPUT}"
 	echo "impacts_all_detected=${impacts_all_detected}" >>"${GITHUB_OUTPUT}"
 	echo "workspace_path=${workspace_path}" >>"${GITHUB_OUTPUT}"
 	echo "requires_default_bazel_installation=${requires_default_bazel_installation}" >>"${GITHUB_OUTPUT}"

--- a/src/scripts/test_wrapper.sh
+++ b/src/scripts/test_wrapper.sh
@@ -81,7 +81,7 @@ touch "${GITHUB_OUTPUT}"
 
 # Use merge base sha instead of merge head sha to calculate the correct diff for testing.
 MERGE_INSTANCE_BRANCH_HEAD_SHA=$(awk -F "=" '$1=="merge_base_sha" {print $2}' "${GITHUB_OUTPUT}")
-PR_BRANCH_HEAD_SHA=$(awk -F "=" '$1=="pr_branch_head_sha" {print $2}' "${GITHUB_OUTPUT}")
+PR_BRANCH_HEAD_SHA=$(awk -F "=" '$1=="pr_branch_testing_head_sha" {print $2}' "${GITHUB_OUTPUT}")
 WORKSPACE_PATH=$(awk -F "=" '$1=="workspace_path" {print $2}' "${GITHUB_OUTPUT}")
 BAZEL_DIFF_CMD=$(awk -F "=" '$1=="bazel_diff_cmd" {print $2}' "${GITHUB_OUTPUT}")
 


### PR DESCRIPTION
I've been accidentally dancing around this issue with #8 and #10. This should be a final fix to the issue by distinguishing between testing and upload modes.

This is necessary for the case:
- PR branch is based off an old version of main
- Current main has a new target that doesn't exist in the PR branch
- Merge-base is computed using PR branch vs. HEAD
- The new target needs to be correctly computed for upload (if applicable), but it should not be included in the filtered testing/query set.

Unfortunately this case is difficult to write tests for, so we will leave it to continue marinating.

This will affect (non-blocking) testing in main but not anywhere else since the upload cases are pinned to v1.