### PR TITLE
Support test wrapper

### DIFF
--- a/src/scripts/test_impacted_targets.sh
+++ b/src/scripts/test_impacted_targets.sh
@@ -65,7 +65,8 @@ echo -e "${info_color}Running bazel ${BAZEL_TEST_COMMAND} on ${target_count} tar
 
 echo
 ret=0
-_bazel "${BAZEL_TEST_COMMAND}" --target_pattern_file="${tempdir}/filtered_targets.txt" || ret=$?
+# trunk-ignore(shellcheck): We want to support additional args here.
+_bazel ${BAZEL_TEST_COMMAND} --target_pattern_file="${tempdir}/filtered_targets.txt" || ret=$?
 
 # Lazily cleanup tempdir since we rely on other wrappers' trap invocations
 if [[ -n ${tempdir+x} ]]; then

--- a/src/scripts/test_wrapper.sh
+++ b/src/scripts/test_wrapper.sh
@@ -95,7 +95,7 @@ touch "${GITHUB_OUTPUT}"
 . "${scripts_dir}/compute_impacted_targets.sh"
 
 IMPACTED_TARGETS_FILE=$(awk -F "=" '$1=="impacted_targets_out" {print $2}' "${GITHUB_OUTPUT}")
-BAZEL_TEST_COMMAND="test"
+BAZEL_TEST_COMMAND="test --test_tag_filters=-manual"
 BAZEL_KIND_FILTER=".+_library|.+_binary|.+_test"
 BAZEL_SCOPE_FILTER=""
 BAZEL_NEGATIVE_KIND_FILTER="generated file"


### PR DESCRIPTION
With these changes, `test_wrapper.sh` matches parity with the internal script and can be dogfooded.