### PR TITLE
Remove CI Debugger

### DIFF
--- a/.github/workflows/compute_impacted_tests.yaml
+++ b/.github/workflows/compute_impacted_tests.yaml
@@ -29,13 +29,8 @@ jobs:
 
       - name: Compute Impacted Targets
         id: compute
-        uses: trunk-io/breakpoint@v1.3.0
-        with:
-          breakpoint-id: trunk-bazel-action
-          run: ./src/scripts/compute_impacted_targets.sh
-          trunk-token: ${{ secrets.TRUNK_DEBUGGER_TOKEN }}
-          org: trunk-staging-org
-          shell: bash
+        run: ./src/scripts/compute_impacted_targets.sh
+        shell: bash
         env:
           MERGE_INSTANCE_BRANCH: do_not_delete/stable_test_branch
           MERGE_INSTANCE_BRANCH_HEAD_SHA: 3e8b2a57e0f3ad7b63cc487eae576c25b84b653b
@@ -47,7 +42,6 @@ jobs:
           BAZEL_PATH: bazel
           BAZEL_DIFF_CMD: ${{ steps.bazel-diff.outputs.bazel_diff_cmd }}
           BAZEL_DIFF_COMMAND_OPTIONS: --remote_cache=
-          TRUNK_API_ADDRESS: api.trunk-staging.io:8443
 
       - name: Validate Impacted Targets Computation
         shell: bash

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install pnpm
-        uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598
+        uses: pnpm/action-setup@eae0cfeb286e66ffb5155f1a79b90583a127a68b
         with:
           version: 8.6.7
 

--- a/action.yaml
+++ b/action.yaml
@@ -72,14 +72,6 @@ inputs:
   test-negative-tag-filter:
     description: Negative tag filter to apply to impacted targets
     required: false
-  enable-trunk-ci-debugger:
-    description: Enable support for the Trunk ci debugger (https://docs.trunk.io/ci-debugger)
-    required: false
-    default: false
-  trunk-ci-debugger-breakpoint-name:
-    description: Name of the trunk breakpoint to apply
-    required: false
-    default: my-breakpoint
 
 runs:
   using: composite
@@ -179,34 +171,11 @@ runs:
         BAZEL_STARTUP_OPTIONS: ${{ inputs.bazel-startup-options }}
 
     - name: Test Impacted Targets
-      if: inputs.test-targets == 'true' && !inputs.enable-trunk-ci-debugger
+      if: inputs.test-targets == 'true'
       id: test-impacted-targets
       run: ${GITHUB_ACTION_PATH}/src/scripts/test_impacted_targets.sh
       working-directory: ${{ steps.prerequisites.outputs.workspace_path }}
       shell: bash
-      env:
-        IMPACTED_TARGETS_FILE:
-          ${{ steps.compute-impacted-targets-test.outputs.impacted_targets_out }}
-        BAZEL_PATH: ${{ inputs.bazel-path }}
-        BAZEL_TEST_COMMAND: ${{ inputs.bazel-test-command }}
-        BAZEL_STARTUP_OPTIONS: ${{ inputs.bazel-startup-options }}
-        BAZEL_KIND_FILTER: ${{ inputs.test-kind-filter }}
-        BAZEL_SCOPE_FILTER: ${{ inputs.test-scope-filter }}
-        BAZEL_NEGATIVE_KIND_FILTER: ${{ inputs.test-negative-kind-filter }}
-        BAZEL_NEGATIVE_SCOPE_FILTER: ${{ inputs.test-negative-scope-filter }}
-        BAZEL_NEGATIVE_TAG_FILTER: ${{ inputs.test-negative-tag-filter }}
-        CI: "true"
-
-    - name: Test Impacted Targets (with debugger)
-      if: inputs.test-targets == 'true' && inputs.enable-trunk-ci-debugger
-      id: test-impacted-targets-dbg
-      uses: trunk-io/breakpoint@v1
-      with:
-        breakpoint-id: ${{ inputs.trunk-ci-debugger-breakpoint-name }}
-        trunk-token: ${{ inputs.trunk-token }}
-        run: ${{ github.action_path }}/src/scripts/test_impacted_targets.sh
-        working-directory: ${{ steps.prerequisites.outputs.workspace_path }}
-        shell: bash
       env:
         IMPACTED_TARGETS_FILE:
           ${{ steps.compute-impacted-targets-test.outputs.impacted_targets_out }}


### PR DESCRIPTION
CI Debugger has been deprecated, so remove references to it and its now unused action inputs.